### PR TITLE
updated way to get info about images from a specific archive

### DIFF
--- a/tutorials/gc_api_tutorial.ipynb
+++ b/tutorials/gc_api_tutorial.ipynb
@@ -280,20 +280,24 @@
     }
    ],
    "source": [
+    "# Get information about images in archive from GC API\n",
+    "response = c(url=\"https://grand-challenge.org/api/v1/cases/images\", params={'archive': corona_archive['id']})\n",
+    "images = response['results']\n",
+    "\n",
     "# Create image mapping, from image URL to original image mha name\n",
     "images_mapping = {}\n",
-    "for image_url in corona_archive[\"images\"]:\n",
+    "for image in images:\n",
     "    # get name of mha image from GC API\n",
-    "    image = c(url=image_url)\n",
     "    images_mapping[image[\"files\"][0][\"file\"]] = image[\"name\"]\n",
     "\n",
     "print(\"Downloading {0} images..\".format(len(images_mapping)))\n",
+    "\n",
     "\n",
     "counter = 0\n",
     "for file1, name1 in images_mapping.items():\n",
     "    response = c.get(file1)\n",
     "    response.raise_for_status()\n",
-    "    with open(os.path.join(output_dir, name1), 'wb') as f1:\n",
+    "    with open(os.path.join(output_archive_dir, name1), 'wb') as f1:\n",
     "        f1.write(response.content)\n",
     "    counter += 1\n",
     "    print(counter)\n",
@@ -368,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi Khrystyna, the tutorial showed a way for getting the image urls from the coronacases.org archive that didn't work for me. Maybe I am doing something wrong, or the GC API has changed? If the latter is the case, I found this solution works for me. 